### PR TITLE
Add performance benchmarking for build steps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       # See: https://github.com/spring-gradle-plugins/dependency-management-plugin/issues/370
       - name: Build backend
         run: |
-          PERFORMANCE_BENCHMARK_SECONDS=300
+          PERFORMANCE_BENCHMARK_SECONDS=260
           start_time=$(date +%s)
           ./gradlew classes jar bootJar
           status=$?
@@ -194,7 +194,7 @@ jobs:
 
       - name: Build webapp
         run: |
-          PERFORMANCE_BENCHMARK_SECONDS=100
+          PERFORMANCE_BENCHMARK_SECONDS=110
           start_time=$(date +%s)
           ./gradlew buildWebapp
           status=$?

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,6 @@ jobs:
           status=$?
           end_time=$(date +%s)
           duration=$((end_time - start_time))
-          echo "Build duration: ${duration}s"
           if [ $duration -gt $PERFORMANCE_BENCHMARK_SECONDS ]; then
             echo "Backend build failed to meet performance benchmarks (>${duration}s > ${PERFORMANCE_BENCHMARK_SECONDS}s)"
             exit 1
@@ -195,13 +194,12 @@ jobs:
 
       - name: Build webapp
         run: |
-          PERFORMANCE_BENCHMARK_SECONDS=35
+          PERFORMANCE_BENCHMARK_SECONDS=100
           start_time=$(date +%s)
           ./gradlew buildWebapp
           status=$?
           end_time=$(date +%s)
           duration=$((end_time - start_time))
-          echo "Build duration: ${duration}s"
           if [ $duration -gt $PERFORMANCE_BENCHMARK_SECONDS ]; then
             echo "Frontend build failed to meet performance benchmarks (>${duration}s > ${PERFORMANCE_BENCHMARK_SECONDS}s)"
             exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,19 @@ jobs:
       # It's very occasional, and doesn't seem to occur locally, but parallel being the issue is possible
       # See: https://github.com/spring-gradle-plugins/dependency-management-plugin/issues/370
       - name: Build backend
-        run: ./gradlew classes jar bootJar
+        run: |
+          PERFORMANCE_BENCHMARK_SECONDS=300
+          start_time=$(date +%s)
+          ./gradlew classes jar bootJar
+          status=$?
+          end_time=$(date +%s)
+          duration=$((end_time - start_time))
+          echo "Build duration: ${duration}s"
+          if [ $duration -gt $PERFORMANCE_BENCHMARK_SECONDS ]; then
+            echo "Backend build failed to meet performance benchmarks (>${duration}s > ${PERFORMANCE_BENCHMARK_SECONDS}s)"
+            exit 1
+          fi
+          exit $status
 
       - name: Upload backend build result
         uses: ./.github/actions/upload-backend-build
@@ -182,7 +194,19 @@ jobs:
         uses: ./.github/actions/setup-env
 
       - name: Build webapp
-        run: ./gradlew buildWebapp
+        run: |
+          PERFORMANCE_BENCHMARK_SECONDS=35
+          start_time=$(date +%s)
+          ./gradlew buildWebapp
+          status=$?
+          end_time=$(date +%s)
+          duration=$((end_time - start_time))
+          echo "Build duration: ${duration}s"
+          if [ $duration -gt $PERFORMANCE_BENCHMARK_SECONDS ]; then
+            echo "Frontend build failed to meet performance benchmarks (>${duration}s > ${PERFORMANCE_BENCHMARK_SECONDS}s)"
+            exit 1
+          fi
+          exit $status
         env:
           TOLGEE_API_KEY: ${{secrets.TOLGEE_API_KEY}}
           TOLGEE_API_URL: ${{secrets.TOLGEE_API_URL}}


### PR DESCRIPTION
Updates `test.yml` workflow to measure backend and frontend build times and cause the build to fail if either build time fails to meet the benchmarks measured [here](https://github.com/hydrofluorich/cs489-tolgee-platform/actions/runs/16121642826).